### PR TITLE
Direct terminal children of the root will now match properly

### DIFF
--- a/ac_fast.cxx
+++ b/ac_fast.cxx
@@ -216,37 +216,48 @@ Match(AC_Buffer* buf, const char* str, uint32 len) {
     unsigned char* root_goto = buf_base + buf->root_goto_ofst;
     AC_Ofst* states_ofst_vect = (AC_Ofst* )(buf_base + buf->states_ofst_ofst);
 
-    AC_State* state;
+    State_ID next_state = 0;
     uint32 idx = 0;
 
     // Skip leading chars that are not valid input of root-nodes.
     if (likely(buf->root_goto_num != 255)) {
         while(idx < len) {
-            unsigned char c = str[idx++];
-            if (unsigned char kid_id = root_goto[c]) {
-                state = Get_State_Addr(buf_base, states_ofst_vect, kid_id);
+            InputTy c = str[idx++];
+            if ((next_state = root_goto[c]) != 0) {
                 break;
             }
         }
     } else {
         idx = 1;
-        state = Get_State_Addr(buf_base, states_ofst_vect, *str);
+        next_state = *str;
     }
 
-    while (idx < len) {
-        unsigned char c = str[idx];
+    while (idx <= len) {
+        AC_State* state = Get_State_Addr(buf_base, states_ofst_vect, next_state);
+        // Check to see if the state is terminal state?
+        if (state->is_term) {
+            ac_result_t r;
+            r.match_begin = idx - state->depth;
+            r.match_end = idx - 1;
+            return r;
+        }
+
+        if (idx >= len) {
+            break;
+        }
+
+        InputTy c = str[idx];
         int res;
         bool found;
         found = Binary_Search_Input(state->input_vect, state->goto_num, c, res);
         if (found) {
             // The "t = goto(c, current_state)" is valid, advance to state "t".
-            uint32 kid = state->first_kid + res;
-            state = Get_State_Addr(buf_base, states_ofst_vect, kid);
+            next_state = state->first_kid + res;
             idx++;
         } else {
             // Follow the fail-link.
-            State_ID fl = state->fail_link;
-            if (fl == 0) {
+            next_state = state->fail_link;
+            if (next_state == 0) {
                 // fail-link is root-node, which implies the root-node dosen't
                 // have 255 valid transitions (otherwise, the fail-link should
                 // points to "goto(root, c)"), so we don't need speical handling
@@ -254,23 +265,11 @@ Match(AC_Buffer* buf, const char* str, uint32 len) {
                 //
                 while(idx < len) {
                     InputTy c = str[idx++];
-                    if (unsigned char kid_id = root_goto[c]) {
-                        state =
-                            Get_State_Addr(buf_base, states_ofst_vect, kid_id);
+                    if ((next_state = root_goto[c]) != 0) {
                         break;
                     }
                 }
-            } else {
-                state = Get_State_Addr(buf_base, states_ofst_vect, fl);
             }
-        }
-
-        // Check to see if the state is terminal state?
-        if (state->is_term) {
-            ac_result_t r;
-            r.match_begin = idx - state->depth;
-            r.match_end = idx - 1;
-            return r;
         }
     }
 

--- a/tests/ac_test_simple.cxx
+++ b/tests/ac_test_simple.cxx
@@ -202,3 +202,7 @@ Tests test7("test 7", dict7, 1, strpair7, 1);
 const char *dict8[] = {"aaab"};
 StrPair strpair8[] = {{"aaaaaaab", "aaab"}};
 Tests test8("test 8", dict8, 1, strpair8, 1);
+
+const char *dict9[] = {"z"};
+StrPair strpair9[] = {{"aaaaz", "z"}};
+Tests test9("test 9", dict9, 1, strpair9, 1);


### PR DESCRIPTION
This is a bug unlikely to ever be seen, but still a bug.  Also, these alterations to Match seem to have made the loop slightly faster (about 5% -- running old/new 60 seconds each) in a [simple (large dictionary) benchmark](https://github.com/Mischanix/lua-aho-corasick/blob/win32-testbed/tests/bench_main.cxx).  Looking at the assembly, it looks like this is attributable to a register getting freed up somewhere along the way.  (compiler: gcc 4.8.2 x86_64 on Windows; processor: Ivy Bridge i3770k)
